### PR TITLE
Move handlebars-helpers to a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "devDependencies": {
         "ava": "^4.0.0",
         "handlebars": "^4.7.7",
+        "handlebars-helpers": "^0.10.0",
         "jsdoc": "^3.6.7",
         "lodash": "^4.17.21",
         "prettier": "^2.5.1",
@@ -46,7 +47,6 @@
         "watch": "^0.13.0"
     },
     "dependencies": {
-        "got": "^12.0.0",
-        "handlebars-helpers": "^0.10.0"
+        "got": "^12.0.0"
     }
 }


### PR DESCRIPTION
This was causing us to publish unnecessary code to NPM
