### PR TITLE
Remove JWT token use internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2022-05-14
+
+### Updated
+
+- Use Basic authentication internally instead of Bearer to simplify and improve performance
+- Internal cleanup of redundant x-account-id headers
+
 ## [1.0.2] - 2022-05-10
 
 ### Updated

--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -349,15 +349,10 @@ export class Accounts {
    * @tag Accounts
    */
   async create(account) {
-    const token = await this.moov.getToken();
-
     const result = await this.moov
       .got({
         url: `accounts`,
         method: "POST",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-        },
         json: account,
       })
       .json();
@@ -375,9 +370,6 @@ export class Accounts {
    */
    async list(accountID, criteria) {
     checkString(accountID).or(Err.AccountID);
-
-    const token = await this.moov.getToken(accountID);
-
     let params = "";
 
     if(criteria) {
@@ -393,12 +385,6 @@ export class Accounts {
       .got({
         url: `accounts${params}`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-          "x-account-id": this.moov.credentials.accountID,
-        },
       })
       .json();
 
@@ -414,16 +400,10 @@ export class Accounts {
    */
   async get(connectedAccountID) {
     checkString(connectedAccountID).or(Err.AccountID);
-
-    const token = await this.moov.getToken(connectedAccountID);
-
     const result = await this.moov
       .got({
         url: `accounts/${connectedAccountID}`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-        },
       })
       .json();
 
@@ -454,7 +434,6 @@ export class Accounts {
   async patch(account) {
     checkString(account.accountID).or(Err.AccountID);
 
-    const token = await this.moov.getToken(account.accountID);
     const patchAccount = { ...account };
 
     delete patchAccount.accountID;
@@ -463,9 +442,6 @@ export class Accounts {
       .got({
         url: `accounts/${account.accountID}`,
         method: "PATCH",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-        },
         json: patchAccount,
       })
       .json();
@@ -483,15 +459,10 @@ export class Accounts {
    async getCountries(accountID) {
     checkString(accountID).or(Err.AccountID);
 
-    const token = await this.moov.getToken(accountID);
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/countries`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-        },
       })
       .json();
 
@@ -510,15 +481,10 @@ export class Accounts {
     checkString(accountID).or(Err.AccountID);
     check(countries).or(Err.MISSING_COUNTRIES);
 
-    const token = await this.moov.getToken(accountID);
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/countries`,
         method: "PUT",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-        },
         json: countries,
       })
       .json();

--- a/lib/avatars.js
+++ b/lib/avatars.js
@@ -31,16 +31,11 @@ export class Avatars {
    */
   async get(uniqueId) {
     checkString(uniqueId).or(Err.MISSING_UNIQUE_ID_ERROR_MESSAGE);
-
-      const token = await this.moov.getToken();
       
       const result = await this.moov
           .got({
               url: `avatars/${uniqueId}`,
               method: "GET",
-              headers: {
-                  authorization: `Bearer ${token.token}`,
-              },
           })
           .blob();
 

--- a/lib/bankAccounts.js
+++ b/lib/bankAccounts.js
@@ -70,18 +70,10 @@ export class BankAccounts {
       }
     }
 
-    const token = await this.moov.getToken(accountID);
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/bank-accounts`,
         method: "POST",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-          "x-account-id": this.moov.credentials.accountID,
-        },
         json: payload,
       })
       .json();
@@ -102,17 +94,10 @@ export class BankAccounts {
     checkString(accountID).or(Err.AccountID);
     checkString(bankAccountID).or(Err.BankAccountID);
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/bank-accounts/${bankAccountID}`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-        },
       })
       .json();
 
@@ -130,17 +115,10 @@ export class BankAccounts {
    async list(accountID) {
     checkString(accountID).or(Err.AccountID);
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/bank-accounts`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-        },
       })
       .json();
 
@@ -160,17 +138,10 @@ export class BankAccounts {
     checkString(accountID).or(Err.AccountID);
     checkString(bankAccountID).or(Err.BankAccountID);
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/bank-accounts/${bankAccountID}`,
         method: "DELETE",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-        },
       })
       .json();
 
@@ -190,17 +161,10 @@ export class BankAccounts {
     checkString(accountID).or(Err.AccountID);
     checkString(bankAccountID).or(Err.BankAccountID);
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/bank-accounts/${bankAccountID}/micro-deposits`,
         method: "POST",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-        },
       })
       .json();
 
@@ -222,17 +186,10 @@ export class BankAccounts {
     checkString(bankAccountID).or(Err.BankAccountID);
     check(amounts).or(Err.MISSING_AMOUNTS);
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/bank-accounts/${bankAccountID}/micro-deposits`,
         method: "PUT",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-        },
         json: {"amounts": amounts},
       })
       .json();

--- a/lib/capabilities.js
+++ b/lib/capabilities.js
@@ -371,18 +371,10 @@ export class Capabilities {
     checkString(accountID).or(Err.AccountID);
     check(capabilities).or(Err.MISSING_CAPABILITIES);
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/capabilities`,
         method: "POST",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-          "x-account-id": this.moov.credentials.accountID,
-        },
         json: {"capabilities": capabilities},
       })
       .json();
@@ -403,18 +395,10 @@ export class Capabilities {
     checkString(accountID).or(Err.AccountID);
     checkString(capability).or(Err.MISSING_CAPABILITY);
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/capabilities/${capability}`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-          "x-account-id": this.moov.credentials.accountID,
-        },
       })
       .json();
 
@@ -432,18 +416,10 @@ export class Capabilities {
    async list(accountID) {
     checkString(accountID).or(Err.AccountID);
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/capabilities`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-          "x-account-id": this.moov.credentials.accountID,
-        },
       })
       .json();
 
@@ -463,18 +439,10 @@ export class Capabilities {
     checkString(accountID).or(Err.AccountID);
     checkString(capability).or(Err.MISSING_CAPABILITY);
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/capabilities/${capability}`,
         method: "DELETE",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-          "x-account-id": this.moov.credentials.accountID,
-        },
       })
       .json();
 

--- a/lib/cards.js
+++ b/lib/cards.js
@@ -188,15 +188,10 @@ export const CARD_BRAND = {
     checkString(accountID).or(Err.AccountID);
     checkString(cardID).or(Err.CardID);
 
-    const token = await this.moov.getToken(accountID);
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/cards/${cardID}`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-        },
       })
       .json();
 
@@ -213,15 +208,10 @@ export const CARD_BRAND = {
    async list(accountID) {
     checkString(accountID).or(Err.AccountID);
 
-    const token = await this.moov.getToken(accountID);
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/cards`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-        },
       })
       .json();
 
@@ -240,15 +230,10 @@ export const CARD_BRAND = {
     checkString(accountID).or(Err.AccountID);
     checkString(cardID).or(Err.CardID);
 
-    const token = await this.moov.getToken(accountID);
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/cards/${cardID}`,
         method: "DELETE",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-        },
       })
       .json();
 

--- a/lib/enrichedAddress.js
+++ b/lib/enrichedAddress.js
@@ -68,14 +68,9 @@ export class EnrichedAddresses {
     check(criteria).or(Err.MISSING_CRITERIA_ERROR_MESSAGE);
     checkString(criteria.search).or(Err.MISSING_ENRICH_ADDRESS_SEARCH_ERROR_MESSAGE);
 
-    const token = await this.moov.getToken();
-
     const options = {
       url: "enrichment/address",
       method: "GET",
-      headers: {
-        authorization: `Bearer ${token.token}`,
-      },
     };
 
     if (criteria) {

--- a/lib/enrichedProfile.js
+++ b/lib/enrichedProfile.js
@@ -100,15 +100,10 @@ export class EnrichedProfiles {
   async get(email) {
     checkString(email).or(Err.MISSING_EMAIL_ERROR_MESSAGE);
 
-    const token = await this.moov.getToken();
-
     const result = await this.moov
       .got({
         url: "enrichment/profile",
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-        },
         searchParams: {
           email: email
         }

--- a/lib/institutions.js
+++ b/lib/institutions.js
@@ -168,17 +168,10 @@ import { Err } from "./helpers/errors.js";
       params.append("routingNumber", criteria.routingNumber);
     }
 
-    const token = await this.moov.getToken()
-
     const result = await this.moov
       .got({
         url: `institutions/${rail}/search`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-        },
         searchParams: params
       })
       .json();

--- a/lib/moov.js
+++ b/lib/moov.js
@@ -226,9 +226,8 @@ export class Moov {
     this.tokenCache = {};
     this.got = got.extend(
       {
-        headers: {
-          authorization: `Basic ${Buffer.from(`${this.credentials.publicKey}:${this.credentials.secretKey}`).toString("base64")}`,
-        },
+        username: this.credentials.publicKey,
+        password: this.credentials.secretKey,
       },
       gotDefaults,
       gotOptionsOrInstance || {}

--- a/lib/moov.js
+++ b/lib/moov.js
@@ -227,7 +227,7 @@ export class Moov {
     this.got = got.extend(
       {
         headers: {
-          origin: this.credentials.domain,
+          authorization: `Basic ${Buffer.from(`${this.credentials.publicKey}:${this.credentials.secretKey}`).toString("base64")}`,
         },
       },
       gotDefaults,
@@ -282,6 +282,9 @@ export class Moov {
         client_secret: this.credentials.secretKey,
         scope: renderedScopes.join(" "),
       },
+      headers: {
+        origin: this.credentials.domain,
+      }
     }).json();
 
     const expiresOn = new Date(new Date().getTime() + result.expires_in * 1000);
@@ -308,14 +311,9 @@ export class Moov {
    * }
    */
   async ping() {
-    const token = await this.getToken();
-
     await this.got({
       url: "ping",
       method: "GET",
-      headers: {
-        Authorization: `Bearer ${token.token}`,
-      },
     });
   }
 

--- a/lib/paymentMethods.js
+++ b/lib/paymentMethods.js
@@ -98,18 +98,10 @@ import { Err } from "./helpers/errors.js";
     checkString(accountID).or(Err.AccountID);
     checkString(paymentMethodID).or(Err.PaymentMethodID)
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/payment-methods/${paymentMethodID}`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-          "x-account-id": this.moov.credentials.accountID,
-        },
       })
       .json();
 
@@ -127,18 +119,10 @@ import { Err } from "./helpers/errors.js";
    async list(accountID) {
     checkString(accountID).or(Err.AccountID);
     
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/payment-methods`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-          "x-account-id": this.moov.credentials.accountID,
-        },
       })
       .json();
 

--- a/lib/representatives.js
+++ b/lib/representatives.js
@@ -157,18 +157,10 @@ import { Err } from "./helpers/errors.js";
     checkString(accountID).or(Err.AccountID);
     check(representative).or(Err.MISSING_REPRESENTATIVE_ERROR_MESSAGE);
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/representatives`,
         method: "POST",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-          "x-account-id": this.moov.credentials.accountID,
-        },
         json: representative,
       })
       .json();
@@ -186,18 +178,10 @@ import { Err } from "./helpers/errors.js";
    async list(accountID) {
     checkString(accountID).or(Err.AccountID);
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/representatives`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-          "x-account-id": this.moov.credentials.accountID,
-        },
       })
       .json();
 
@@ -216,18 +200,10 @@ import { Err } from "./helpers/errors.js";
     checkString(accountID).or(Err.AccountID);
     checkString(representativeID).or(Err.RepresentativeID);
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/representatives/${representativeID}`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-          "x-account-id": this.moov.credentials.accountID,
-        },
       })
       .json();
 
@@ -246,18 +222,10 @@ import { Err } from "./helpers/errors.js";
     checkString(accountID).or(Err.AccountID);
     checkString(representativeID).or(Err.RepresentativeID);
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/representatives/${representativeID}`,
         method: "DELETE",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-          "x-account-id": this.moov.credentials.accountID,
-        },
       })
       .json();
 
@@ -278,18 +246,10 @@ import { Err } from "./helpers/errors.js";
     checkString(representativeID).or(Err.RepresentativeID);
     check(representative).or(Err.MISSING_REPRESENTATIVE_ERROR_MESSAGE);
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/representatives/${representativeID}`,
         method: "PATCH",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-          "x-account-id": this.moov.credentials.accountID,
-        },
         json: representative,
       })
       .json();

--- a/lib/transfers.js
+++ b/lib/transfers.js
@@ -283,14 +283,11 @@ export class Transfers {
   async create(transfer) {
     check(transfer).or(Err.MISSING_TRANSFER_ERROR_MESSAGE);
 
-    const token = await this.moov.getToken();
-
     const result = await this.moov
       .got({
         url: `transfers`,
         method: "POST",
         headers: {
-          authorization: `Bearer ${token.token}`,
           "x-idempotency-key": randomUUID(),
         },
         json: transfer,
@@ -324,14 +321,9 @@ export class Transfers {
    * }
    */
   async list(criteria) {
-    const token = await this.moov.getToken();
-
     const options = {
       url: "transfers",
       method: "GET",
-      headers: {
-        authorization: `Bearer ${token.token}`,
-      },
     };
 
     if (criteria) {
@@ -382,16 +374,10 @@ export class Transfers {
   async get(transferID) {
     checkString(transferID).or(Err.TransferID);
 
-    const token = await this.moov.getToken();
-
     const result = await this.moov
       .got({
         url: `transfers/${transferID}`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          "x-account-id": this.moov.credentials.accountID,
-        },
       })
       .json();
 
@@ -420,16 +406,10 @@ export class Transfers {
   async updateMetadata(transferID, metadata) {
     checkString(transferID).or(Err.TransferID);
 
-    const token = await this.moov.getToken();
-
     const result = await this.moov
       .got({
         url: `transfers/${transferID}`,
         method: "PATCH",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          "x-account-id": this.moov.credentials.accountID,
-        },
         json: {
           metadata,
         },
@@ -470,16 +450,10 @@ export class Transfers {
   async getTransferOptions(transferOptionsCriteria) {
     check(transferOptionsCriteria).or(Err.MISSING_TRANSFER_OPTION_CRITERIA_ERROR_MESSAGE);
 
-    const token = await this.moov.getToken();
-
     const result = await this.moov
       .got({
         url: `transfer-options`,
         method: "POST",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          "x-account-id": this.moov.credentials.accountID,
-        },
         json: transferOptionsCriteria,
       })
       .json();
@@ -505,14 +479,11 @@ export class Transfers {
   async refund(transferID) {
     checkString(transferID).or(Err.TransferID);
 
-    const token = await this.moov.getToken();
-
     const result = await this.moov
       .got({
         url: `transfers/${transferID}/refunds`,
         method: "POST",
         headers: {
-          authorization: `Bearer ${token.token}`,
           "x-idempotency-key": randomUUID(),
         },
       })
@@ -539,15 +510,10 @@ export class Transfers {
   async listRefunds(transferID) {
     checkString(transferID).or(Err.TransferID);
 
-    const token = await this.moov.getToken();
-
     const result = await this.moov
       .got({
         url: `transfers/${transferID}/refunds`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-        },
       })
       .json();
 
@@ -574,15 +540,10 @@ export class Transfers {
     checkString(transferID).or(Err.TransferID);
     checkString(refundID).or(Err.RefundID);
 
-    const token = await this.moov.getToken();
-
     const result = await this.moov
       .got({
         url: `transfers/${transferID}/refunds/${refundID}`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-        },
       })
       .json();
 

--- a/lib/wallets.js
+++ b/lib/wallets.js
@@ -53,18 +53,10 @@ import { Err } from "./helpers/errors.js";
      checkString(accountID).or(Err.AccountID);
      checkString(walletID).or(Err.WalletID);
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/wallets/${walletID}`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-          "x-account-id": this.moov.credentials.accountID,
-        },
       })
       .json();
 
@@ -82,18 +74,10 @@ import { Err } from "./helpers/errors.js";
    async list(accountID) {
     checkString(accountID).or(Err.AccountID);
 
-    const token = await this.moov.getToken(accountID)
-
     const result = await this.moov
       .got({
         url: `accounts/${accountID}/wallets`,
         method: "GET",
-        headers: {
-          authorization: `Bearer ${token.token}`,
-          origin: this.moov.credentials.domain,
-          referer: this.moov.credentials.domain,
-          "x-account-id": this.moov.credentials.accountID,
-        },
       })
       .json();
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
     "name": "@moovio/node",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Node SDK for the Moov API and Dashboard",
     "module": "dist/mjs/index.js",
     "main": "dist/cjs/index.js",
+    "type": "module",
     "exports": {
         ".": {
             "import": "./dist/mjs/index.js",


### PR DESCRIPTION
Internally the API will use Basic authentication instead of Bearer, meaning a token with scopes doesn't need to be generated for server-side use. 

It's still possible to generate a token for client-side use with the `generateToken()` method.