### PR TITLE
cardDetails had the wrong tag and outdated model

### DIFF
--- a/lib/cardDetails.js
+++ b/lib/cardDetails.js
@@ -2,8 +2,8 @@
  * @typedef CardDetails
  * @type {object}
  * @property {string} dynamicDescriptor -An optional override of the default card statement descriptor for a single transfer.
- * @property {"recurring"|"unscheduled"|null} merchantInitiatedType - Enum: [recurring unscheduled] Describes how the card transaction was initiated
- * @tag Cards
+ * @property {"first-recurring"|"recurring"|"unscheduled"|null} transactionSource - Enum: [first-recurring recurring unscheduled] Describes how the card transaction was initiated
+ * @tag Transfers
  */
  
 exports.unused = {};


### PR DESCRIPTION
`cardDetails` was showing in the docs on the Cards page which makes sense at a glance except this particular model is part of a transfer's source.