### PR TITLE
Docs facilitator language

### DIFF
--- a/docs/output/accounts.md
+++ b/docs/output/accounts.md
@@ -67,7 +67,7 @@ accounts.get(connectedAccountID)
 {{< table >}}
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| connectedAccountID |  `string` | User account to query |
+| connectedAccountID |  `string` | Account to query |
 {{</ table >}}
 
 

--- a/docs/output/accounts.md
+++ b/docs/output/accounts.md
@@ -67,7 +67,7 @@ accounts.get(connectedAccountID)
 {{< table >}}
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| connectedAccountID |  `string` | Account to query |
+| connectedAccountID |  `string` | User account to query |
 {{</ table >}}
 
 

--- a/docs/output/authentication.md
+++ b/docs/output/authentication.md
@@ -18,9 +18,9 @@ moov.generateToken(scopes, accountID)
 **Parameters**
 {{< table >}}
 | Name | Type | Description |
-| ---- | ---- | ----------- |a
+| ---- | ---- | ----------- |
 | scopes |  Array.<[SCOPES](#scopes)> | One or more permissions to request |
-| accountID |  `string` | Account on which to request permissions, default is facilitator account ID |
+| accountID |  `string` | Account on which to request permissions, default is your account ID |
 {{</ table >}}
 
 

--- a/docs/output/authentication.md
+++ b/docs/output/authentication.md
@@ -20,7 +20,7 @@ moov.generateToken(scopes, accountID)
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | scopes |  Array.<[SCOPES](#scopes)> | One or more permissions to request |
-| accountID |  `string` | Account on which to request permissions, default is the main account holder's account ID |
+| accountID |  `string` | Account on which to request permissions, default is facilitator account ID |
 {{</ table >}}
 
 

--- a/docs/output/authentication.md
+++ b/docs/output/authentication.md
@@ -18,7 +18,7 @@ moov.generateToken(scopes, accountID)
 **Parameters**
 {{< table >}}
 | Name | Type | Description |
-| ---- | ---- | ----------- |
+| ---- | ---- | ----------- |a
 | scopes |  Array.<[SCOPES](#scopes)> | One or more permissions to request |
 | accountID |  `string` | Account on which to request permissions, default is facilitator account ID |
 {{</ table >}}

--- a/docs/output/authentication.md
+++ b/docs/output/authentication.md
@@ -20,7 +20,7 @@ moov.generateToken(scopes, accountID)
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | scopes |  Array.<[SCOPES](#scopes)> | One or more permissions to request |
-| accountID |  `string` | Account on which to request permissions, default is facilitator account ID |
+| accountID |  `string` | Account on which to request permissions, default is the main account holder's account ID |
 {{</ table >}}
 
 

--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -409,7 +409,7 @@ export class Accounts {
   /**
    * Retrieves details for the account with the specified ID.
    *
-   * @param {string} connectedAccountID - Account to query
+   * @param {string} connectedAccountID - User account to query
    * @returns {Promise<Account>}
    * @tag Accounts
    */

--- a/lib/moov.js
+++ b/lib/moov.js
@@ -243,7 +243,7 @@ export class Moov {
    * Generates an OAuth token required by Moov API requests. For more on our authentication protocol, read our [quick start guide](/guides/quick-start/#create-an-access-token).
    *
    * @param {SCOPES[]} scopes - One or more permissions to request
-   * @param {string} [accountID] - Account on which to request permissions, default is facilitator account ID
+   * @param {string} [accountID] - Account on which to request permissions, default is your account ID
    * @returns {Promise<Token>}
    * @tag Authentication
    *

--- a/lib/types/accounts.d.ts
+++ b/lib/types/accounts.d.ts
@@ -352,7 +352,7 @@ export class Accounts {
     /**
      * Retrieves details for the account with the specified ID.
      *
-     * @param {string} connectedAccountID - Account to query
+     * @param {string} connectedAccountID - User account to query
      * @returns {Promise<Account>}
      * @tag Accounts
      */

--- a/lib/types/moov.d.ts
+++ b/lib/types/moov.d.ts
@@ -88,7 +88,7 @@ export class Moov {
      * Generates an OAuth token required by Moov API requests. For more on our authentication protocol, read our [quick start guide](/guides/quick-start/#create-an-access-token).
      *
      * @param {SCOPES[]} scopes - One or more permissions to request
-     * @param {string} [accountID] - Account on which to request permissions, default is facilitator account ID
+     * @param {string} [accountID] - Account on which to request permissions, default is your account ID
      * @returns {Promise<Token>}
      * @tag Authentication
      *


### PR DESCRIPTION
Alter a reference to facilitator accounts to remove specific language (related to [Docs PR](https://github.com/moovfinancial/docs/pull/781))
**Ignore the first two commits**