### PR TITLE
Decimal precision

### DIFF
--- a/docs/output/Capabilities.md
+++ b/docs/output/Capabilities.md
@@ -278,7 +278,7 @@ Available capabilities
 | DOCUMENT_ADDRESS_MISMATCH | Address mismatch |
 | DOCUMENT_NUMBER_MISMATCH | Number mismatch |
 | DOCUMENT_INCOMPLETE | Incomplete document |
-| DOCUMENT_FAILED_RISK | Failed risk assessment |
+| DOCUMENT_FAILED_RISK |  |
 | DOCUMENT_ILLEGIBLE | Illegible document |
 | DOCUMENT_UNSUPPORTED | Unsupported document type |
 | DOCUMENT_NOT_UPLOADED | Document did not upload |

--- a/docs/output/Capabilities.md
+++ b/docs/output/Capabilities.md
@@ -278,7 +278,7 @@ Available capabilities
 | DOCUMENT_ADDRESS_MISMATCH | Address mismatch |
 | DOCUMENT_NUMBER_MISMATCH | Number mismatch |
 | DOCUMENT_INCOMPLETE | Incomplete document |
-| DOCUMENT_FAILED_RISK |  |
+| DOCUMENT_FAILED_RISK | Failed risk assessment |
 | DOCUMENT_ILLEGIBLE | Illegible document |
 | DOCUMENT_UNSUPPORTED | Unsupported document type |
 | DOCUMENT_NOT_UPLOADED | Document did not upload |

--- a/docs/output/transfers.md
+++ b/docs/output/transfers.md
@@ -44,8 +44,8 @@ try {
       currency: "USD"
     },
     facilitatorFee: {
-      value: 8, // $0.8
-      currency: "USD"
+      total: 8, // $0.8
+      totalDecimal: "0.8049"
     },
     description: "Yoga class"
   };
@@ -547,6 +547,7 @@ Models the reason for an ACH return or correction.
   | refunds | Array.<[Refund](#refund)>| Array of refunds associated with the transfer |
   | facilitatorFee | `object`| Total or markup fee |
   | moovFee | `number`| Integer quantity of Moov fee in USD, so $0.11 would be 11 |
+  | moovFeeDecimal | `string`| The precise fee charged - supports up to 9 decimals |
 
 
 
@@ -586,8 +587,7 @@ Models the reason for an ACH return or correction.
     "value": 1204
   },
   "facilitatorFee": {
-    "total": 0,
-    "markup": 0
+    "total": 0
   },
   "description": "Pay Instructor for May 15 Class",
   "metadata": {

--- a/docs/output/transfers.md
+++ b/docs/output/transfers.md
@@ -44,8 +44,7 @@ try {
       currency: "USD"
     },
     facilitatorFee: {
-      total: 8, // $0.8
-      totalDecimal: "0.8049"
+      total: 8, // $0.08
     },
     description: "Yoga class"
   };
@@ -588,7 +587,6 @@ Models the reason for an ACH return or correction.
   },
   "facilitatorFee": {
     "total": 0,
-    "totalDecimal": "0"
   },
   "description": "Pay Instructor for May 15 Class",
   "metadata": {

--- a/docs/output/transfers.md
+++ b/docs/output/transfers.md
@@ -587,7 +587,8 @@ Models the reason for an ACH return or correction.
     "value": 1204
   },
   "facilitatorFee": {
-    "total": 0
+    "total": 0,
+    "totalDecimal": "0"
   },
   "description": "Pay Instructor for May 15 Class",
   "metadata": {

--- a/lib/capabilities.js
+++ b/lib/capabilities.js
@@ -321,6 +321,7 @@ export const REQUIREMENT_ERROR_CODE = {
    */
   DOCUMENT_INCOMPLETE: "document-incomplete",
   /**
+   * Failed risk assessment
    * @tag Capabilities
    */
   DOCUMENT_FAILED_RISK: "document-failed-risk",

--- a/lib/transfers.js
+++ b/lib/transfers.js
@@ -134,6 +134,7 @@ import { Address } from "./address.js";
  * @property {Refund[]} refunds - Array of refunds associated with the transfer
  * @property {object} facilitatorFee - Total or markup fee
  * @property {number} moovFee - Integer quantity of Moov fee in USD, so $0.11 would be 11
+ * @property {string} moovFeeDecimal - The precise fee charged - supports up to 9 decimals
  * @tag Transfers
  */
 
@@ -161,8 +162,7 @@ import { Address } from "./address.js";
     "value": 1204
   },
   "facilitatorFee": {
-    "total": 0,
-    "markup": 0
+    "total": 0
   },
   "description": "Pay Instructor for May 15 Class",
   "metadata": {
@@ -268,8 +268,8 @@ export class Transfers {
    *       currency: "USD"
    *     },
    *     facilitatorFee: {
-   *       value: 8, // $0.8
-   *       currency: "USD"
+   *       total: 8, // $0.8
+   *       totalDecimal: "0.8049"
    *     },
    *     description: "Yoga class"
    *   };

--- a/lib/transfers.js
+++ b/lib/transfers.js
@@ -162,7 +162,8 @@ import { Address } from "./address.js";
     "value": 1204
   },
   "facilitatorFee": {
-    "total": 0
+    "total": 0,
+    "totalDecimal": "0"
   },
   "description": "Pay Instructor for May 15 Class",
   "metadata": {

--- a/lib/transfers.js
+++ b/lib/transfers.js
@@ -163,7 +163,6 @@ import { Address } from "./address.js";
   },
   "facilitatorFee": {
     "total": 0,
-    "totalDecimal": "0"
   },
   "description": "Pay Instructor for May 15 Class",
   "metadata": {
@@ -269,8 +268,7 @@ export class Transfers {
    *       currency: "USD"
    *     },
    *     facilitatorFee: {
-   *       total: 8, // $0.8
-   *       totalDecimal: "0.8049"
+   *       total: 8, // $0.08
    *     },
    *     description: "Yoga class"
    *   };

--- a/lib/types/transfers.d.ts
+++ b/lib/types/transfers.d.ts
@@ -143,7 +143,8 @@
     "value": 1204
   },
   "facilitatorFee": {
-    "total": 0
+    "total": 0,
+    "totalDecimal": "0"
   },
   "description": "Pay Instructor for May 15 Class",
   "metadata": {

--- a/lib/types/transfers.d.ts
+++ b/lib/types/transfers.d.ts
@@ -144,7 +144,6 @@
   },
   "facilitatorFee": {
     "total": 0,
-    "totalDecimal": "0"
   },
   "description": "Pay Instructor for May 15 Class",
   "metadata": {
@@ -241,8 +240,7 @@ export class Transfers {
      *       currency: "USD"
      *     },
      *     facilitatorFee: {
-     *       total: 8, // $0.8
-     *       totalDecimal: "0.8049"
+     *       total: 8, // $0.08
      *     },
      *     description: "Yoga class"
      *   };

--- a/lib/types/transfers.d.ts
+++ b/lib/types/transfers.d.ts
@@ -116,6 +116,7 @@
  * @property {Refund[]} refunds
  * @property {object} facilitatorFee
  * @property {number} moovFee - Integer quantity of Moov fee in USD, so $0.11 would be 11
+ * @property {string} moovFeeDecimal - The precise fee charged - supports up to 9 decimals
  * @tag Transfers
  */
 /**
@@ -142,8 +143,7 @@
     "value": 1204
   },
   "facilitatorFee": {
-    "total": 0,
-    "markup": 0
+    "total": 0
   },
   "description": "Pay Instructor for May 15 Class",
   "metadata": {
@@ -240,8 +240,8 @@ export class Transfers {
      *       currency: "USD"
      *     },
      *     facilitatorFee: {
-     *       value: 8, // $0.8
-     *       currency: "USD"
+     *       total: 8, // $0.8
+     *       totalDecimal: "0.8049"
      *     },
      *     description: "Yoga class"
      *   };


### PR DESCRIPTION
Updates for decimal precision.
- removes `"markup": 0` from examples (if I understand correctly we'll no longer show this if 0)
- adds `totalDecimal` if 0
- fixes object that had `value` and `currency` - converted to `total` and `totalDecimal`

Also fixes a weird issue with a missing description unrelated to decimal precision.