### PR TITLE
Revert some docs changes

### DIFF
--- a/docs/output/Capabilities.md
+++ b/docs/output/Capabilities.md
@@ -2,7 +2,7 @@
 title: "Capabilities"
 weight: 50
 ---
-Capabilities determine what a Moov account can do. Each capability has specific information requirements, depending on risk and compliance standards associated with different account activities. For more context, read our guide on [capabilities](/guides/accounts/capabilities).
+Capabilities determine what a Moov account can do. Each capability has specific information requirements, depending on risk and compliance standards associated with different account activities. For more context, read our [capabilities](/guides/accounts/capabilities) guide.
 
 
 ## RequestCapabilities

--- a/docs/output/accounts.md
+++ b/docs/output/accounts.md
@@ -409,7 +409,7 @@ Describes a Moov account associated with an individual or a business.
 
 ### TermsOfServiceToken
 
-A token that can then be used to accept Moov's Terms of Service. Must be generated from a web browser. See the [Moovjs](/moovjs/accounts/accounts/#platform-agreement) documentation for more details.
+A token that can then be used to accept Moov's Terms of Service. Must be generated from a web browser. See the [Moovjs](/moovjs/accounts/accounts/#platform-terms-of-service-agreement) documentation for more details.
 
 **Properties**
 

--- a/docs/output/bank-accounts.md
+++ b/docs/output/bank-accounts.md
@@ -2,7 +2,7 @@
 title: "Bank accounts"
 weight: 60
 ---
-To transfer money with Moov, you’ll need to link a bank account to your Moov account, then verify that account. You can link a bank account to a Moov account by adding the bank account number and routing number to the account object. We require micro-deposit verification to reduce the risk of fraud or unauthorized activity. You can verify a bank account by initiating micro-deposits, sending two small credit transfers to the bank account you want to confirm. Alternatively, you can link and verify a bank account in one step through an instant account verification token from a third party provider like Plaid. For more context, read our [guide on bank accounts](/guides/sources/bank-accounts/).
+To transfer money with Moov, you’ll need to link a bank account to your Moov account, then verify that account. You can link a bank account to a Moov account by adding the bank account number and routing number to the account object. We require micro-deposit verification to reduce the risk of fraud or unauthorized activity. You can verify a bank account by initiating micro-deposits, sending two small credit transfers to the bank account you want to confirm. Alternatively, you can link and verify a bank account in one step through an instant account verification token from a third party provider like Plaid. For more context, read our [bank accounts](/guides/sources/bank-accounts/) guide.
 
 
 ## Link

--- a/docs/output/payment-methods.md
+++ b/docs/output/payment-methods.md
@@ -2,7 +2,7 @@
 title: "Payment methods"
 weight: 80
 ---
-Payments methods represent all of the ways an account can move funds to another Moov account. Payment methods are generated programmatically when a card or bank account is added or the status is updated. For example, `ach-debit-fund` will be added as a payment method once the bank account is verified. For more context, read our guide on [payment methods](/guides/money-movement/payment-methods/).
+Payments methods represent all of the ways an account can move funds to another Moov account. Payment methods are generated programmatically when a card or bank account is added or the status is updated. For example, `ach-debit-fund` will be added as a payment method once the bank account is verified. For more context, read our [payment methods](/guides/money-movement/payment-methods/) guide.
 
 
 ## Get

--- a/docs/output/transfers.md
+++ b/docs/output/transfers.md
@@ -3,7 +3,7 @@ title: "Transfers"
 weight: 90
 ---
 
-A transfer is the movement of money between Moov accounts, from source to destination. Provided you have linked a bank account which has been verified, you can initiate a transfer to another Moov account. For more context, read our [guide on transfers](/guides/money-movement).
+A transfer is the movement of money between Moov accounts, from source to destination. Provided you have linked a bank account which has been verified, you can initiate a transfer to another Moov account. For more context, read our [transfers](/guides/money-movement) guide.
 
 
 ## Create

--- a/docs/output/wallets.md
+++ b/docs/output/wallets.md
@@ -4,7 +4,7 @@ weight: 100
 ---
 
 Every Moov account automatically comes with a Moov wallet, which serves as a funding source as you accumulate funds. 
-At this time, wallets can't be manually created, deleted or modified. They are read-only and are automatically created when a Moov account is associated with an application. For more context, read our guide on [wallets](/guides/wallet/).
+At this time, wallets can't be manually created, deleted or modified. They are read-only and are automatically created when a Moov account is associated with an application. For more context, read our [wallets](/guides/wallet/) guide.
 
 
 ## Get

--- a/docs/templates/tag-templates/Bank accounts.hbs
+++ b/docs/templates/tag-templates/Bank accounts.hbs
@@ -2,7 +2,7 @@
 title: "{{name}}"
 weight: {{weight}}
 ---
-To transfer money with Moov, you’ll need to link a bank account to your Moov account, then verify that account. You can link a bank account to a Moov account by adding the bank account number and routing number to the account object. We require micro-deposit verification to reduce the risk of fraud or unauthorized activity. You can verify a bank account by initiating micro-deposits, sending two small credit transfers to the bank account you want to confirm. Alternatively, you can link and verify a bank account in one step through an instant account verification token from a third party provider like Plaid. For more context, read our [guide on bank accounts](/guides/sources/bank-accounts/).
+To transfer money with Moov, you’ll need to link a bank account to your Moov account, then verify that account. You can link a bank account to a Moov account by adding the bank account number and routing number to the account object. We require micro-deposit verification to reduce the risk of fraud or unauthorized activity. You can verify a bank account by initiating micro-deposits, sending two small credit transfers to the bank account you want to confirm. Alternatively, you can link and verify a bank account in one step through an instant account verification token from a third party provider like Plaid. For more context, read our [bank accounts](/guides/sources/bank-accounts/) guide.
 
 {{#each classes}}
   {{~>class}}

--- a/docs/templates/tag-templates/Capabilities.hbs
+++ b/docs/templates/tag-templates/Capabilities.hbs
@@ -2,7 +2,7 @@
 title: "{{name}}"
 weight: {{weight}}
 ---
-Capabilities determine what a Moov account can do. Each capability has specific information requirements, depending on risk and compliance standards associated with different account activities. For more context, read our guide on [capabilities](/guides/accounts/capabilities).
+Capabilities determine what a Moov account can do. Each capability has specific information requirements, depending on risk and compliance standards associated with different account activities. For more context, read our [capabilities](/guides/accounts/capabilities) guide.
 
 {{#each classes}}
   {{~>class}}

--- a/docs/templates/tag-templates/Payment methods.hbs
+++ b/docs/templates/tag-templates/Payment methods.hbs
@@ -2,7 +2,7 @@
 title: "{{name}}"
 weight: {{weight}}
 ---
-Payments methods represent all of the ways an account can move funds to another Moov account. Payment methods are generated programmatically when a card or bank account is added or the status is updated. For example, `ach-debit-fund` will be added as a payment method once the bank account is verified. For more context, read our guide on [payment methods](/guides/money-movement/payment-methods/).
+Payments methods represent all of the ways an account can move funds to another Moov account. Payment methods are generated programmatically when a card or bank account is added or the status is updated. For example, `ach-debit-fund` will be added as a payment method once the bank account is verified. For more context, read our [payment methods](/guides/money-movement/payment-methods/) guide.
 
 {{#each classes}}
   {{~>class}}

--- a/docs/templates/tag-templates/Transfers.hbs
+++ b/docs/templates/tag-templates/Transfers.hbs
@@ -3,7 +3,7 @@ title: "{{name}}"
 weight: {{weight}}
 ---
 
-A transfer is the movement of money between Moov accounts, from source to destination. Provided you have linked a bank account which has been verified, you can initiate a transfer to another Moov account. For more context, read our [guide on transfers](/guides/money-movement).
+A transfer is the movement of money between Moov accounts, from source to destination. Provided you have linked a bank account which has been verified, you can initiate a transfer to another Moov account. For more context, read our [transfers](/guides/money-movement) guide.
 
 {{#each classes}}
   {{~>class}}

--- a/docs/templates/tag-templates/Wallets.hbs
+++ b/docs/templates/tag-templates/Wallets.hbs
@@ -4,7 +4,7 @@ weight: {{weight}}
 ---
 
 Every Moov account automatically comes with a Moov wallet, which serves as a funding source as you accumulate funds. 
-At this time, wallets can't be manually created, deleted or modified. They are read-only and are automatically created when a Moov account is associated with an application. For more context, read our guide on [wallets](/guides/wallet/).
+At this time, wallets can't be manually created, deleted or modified. They are read-only and are automatically created when a Moov account is associated with an application. For more context, read our [wallets](/guides/wallet/) guide.
 
 {{#each classes}}
   {{~>class}}

--- a/docs/templates/tag-templates/bankAccounts.hbs
+++ b/docs/templates/tag-templates/bankAccounts.hbs
@@ -2,7 +2,7 @@
 title: "{{name}}"
 weight: {{weight}}
 ---
-To transfer money with Moov, you’ll need to link a bank account to your Moov account, then verify that account. You can link a bank account to a Moov account by adding the bank account number and routing number to the account object. We require micro-deposit verification to reduce the risk of fraud or unauthorized activity. You can verify a bank account by initiating micro-deposits, sending two small credit transfers to the bank account you want to confirm. Alternatively, you can link and verify a bank account in one step through an instant account verification token from a third party provider like Plaid. For more context, read our [guide on bank accounts](/guides/sources/bank-accounts/).
+To transfer money with Moov, you’ll need to link a bank account to your Moov account, then verify that account. You can link a bank account to a Moov account by adding the bank account number and routing number to the account object. We require micro-deposit verification to reduce the risk of fraud or unauthorized activity. You can verify a bank account by initiating micro-deposits, sending two small credit transfers to the bank account you want to confirm. Alternatively, you can link and verify a bank account in one step through an instant account verification token from a third party provider like Plaid. For more context, read our [bank accounts](/guides/sources/bank-accounts/) guide.
 
 {{#each classes}}
   {{~>class}}

--- a/docs/templates/tag-templates/paymentMethods.hbs
+++ b/docs/templates/tag-templates/paymentMethods.hbs
@@ -2,7 +2,7 @@
 title: "{{name}}"
 weight: {{weight}}
 ---
-Payments methods represent all of the ways an account can move funds to another Moov account. Payment methods are generated programmatically when a card or bank account is added or the status is updated. For example, `ach-debit-fund` will be added as a payment method once the bank account is verified. For more context, read our guide on [payment methods](/guides/money-movement/payment-methods/).
+Payments methods represent all of the ways an account can move funds to another Moov account. Payment methods are generated programmatically when a card or bank account is added or the status is updated. For example, `ach-debit-fund` will be added as a payment method once the bank account is verified. For more context, read our [payment methods](/guides/money-movement/payment-methods/) guide.
 
 {{#each classes}}
   {{~>class}}

--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -204,7 +204,7 @@ import { Address } from "./address.js";
  */
 
 /**
- * A token that can then be used to accept Moov's Terms of Service. Must be generated from a web browser. See the [Moovjs](/moovjs/accounts/accounts/#platform-agreement) documentation for more details.
+ * A token that can then be used to accept Moov's Terms of Service. Must be generated from a web browser. See the [Moovjs](/moovjs/accounts/accounts/#platform-terms-of-service-agreement) documentation for more details.
  * @typedef TermsOfServiceToken
  * @property {string} token - An encrypted value used to record acceptance of Moov's Terms of Service
  * @tag Accounts

--- a/lib/transfers.js
+++ b/lib/transfers.js
@@ -6,7 +6,7 @@ import { Address } from "./address.js";
 /**
  * @typedef CardDetails
  * @type {object}
- * @property {string} dynamicDescriptor -An optional override of the default card statement descriptor for a single transfer
+ * @property {string} dynamicDescriptor - An optional override of the default card statement descriptor for a single transfer
  * @property {"recurring"|"unscheduled"|null} merchantInitiatedType - Enum: [recurring unscheduled] Describes how the card transaction was initiated
  * @tag Cards
  */


### PR DESCRIPTION
Changes were made somewhere that need to be reverted. My best guess is a search and replace was done in docs, which included the Node pages, but they need to be changed here not the docs repo. 

Minor wording changes to a bunch of pages, and one updated link.