### PR TITLE
Bugfix: Exception MESSAGE absent if 'domain' is not provided while cr…

### DIFF
--- a/lib/moov.js
+++ b/lib/moov.js
@@ -220,7 +220,7 @@ export class Moov {
     checkString(credentials.accountID).or(Err.MISSING_ACCOUNT_ID);
     checkString(credentials.publicKey).or(Err.MISSING_PUBLIC_KEY);
     checkString(credentials.secretKey).or(Err.MISSING_SECRET_KEY);
-    checkUrl(credentials.domain).or(Err.DomainRequired);
+    checkUrl(credentials.domain).or(Err.MISSING_DOMAIN);
 
     this.credentials = credentials;
     this.tokenCache = {};


### PR DESCRIPTION
Exception MESSAGE absent if 'domain' is not provided while creating a Moov instance.