### PR TITLE
Improve example scripts

### DIFF
--- a/examples/avatars.js
+++ b/examples/avatars.js
@@ -9,16 +9,13 @@ const UNIQUE_ID = "031100649"; // Discover routing number
  * Demonstrate how to get avatar associated with uniqueID.
  */
 async function run() {
-  // Load credentials and initialize the Moov client
-  const credentials = loadCredentials("./secrets/credentials.json");
-  const moov = new Moov(credentials, gotOptionsForLogging);
+  try {
+    // Load credentials and initialize the Moov client
+    const credentials = loadCredentials("./secrets/credentials.json");
+    const moov = new Moov(credentials, gotOptionsForLogging);
 
-  try
-  {
-    const avatar = moov.avatars.get(UNIQUE_ID);
-  }
-  catch(err)
-  {
+    await moov.avatars.get(UNIQUE_ID);
+  } catch (err) {
     console.error("Error: ", err.message);
   }
 }

--- a/examples/createTransfer.js
+++ b/examples/createTransfer.js
@@ -28,13 +28,15 @@ async function run() {
     amount: TRANSFER_AMOUNT,
   });
 
-  try
-  {
-  // Select ACH
-    const sourcePaymentMethodID = sourceOptions.find(
+  try {
+    // Select ACH
+    const sourceOption = sourceOptions.find(
       (x) => x.paymentMethodType === "ach-debit-fund"
-    ).paymentMethodID;
-
+    );
+    if (!sourceOption) {
+      throw new Error("No ACH debit fund option available");
+    }
+    const sourcePaymentMethodID = sourceOption.paymentMethodID;
     // Get destination transfer options given the source transfer option
     const { destinationOptions } = await moov.transfers.getTransferOptions({
       source: {
@@ -47,12 +49,16 @@ async function run() {
     });
 
     // Select ACH standard
-    const destinationPaymentMethodID = destinationOptions.find(
+    const destinationOption = destinationOptions.find(
       (x) => x.paymentMethodType === "ach-credit-standard"
-    ).paymentMethodID;
+    );
+    if (!destinationOption) {
+      throw new Error("No ACH credit standard option available");
+    }
+    const destinationPaymentMethodID = destinationOption.paymentMethodID;
 
     // Create the transfer
-    const transfer = await moov.transfers.create({
+    await moov.transfers.create({
       source: {
         paymentMethodID: sourcePaymentMethodID,
       },
@@ -61,9 +67,7 @@ async function run() {
       },
       amount: TRANSFER_AMOUNT,
     });
-  }
-  catch(err)
-  {
+  } catch (err) {
     // catch an exception you plan to handle, if not allow it to bubble up
     console.error("Error: ", err.message);
   }


### PR DESCRIPTION
This pull request improves the example scripts in a few ways:

**Avatars:**

- Handled the promise returned by `moov.avatars.get(UNIQUE_ID)` by awaiting it 
- Wrapped the code that loads the credentials and initializes the Moov client in a try-catch block to handle any errors that occur during these operations

**Create Transfer:**

- Added checks to ensure a matching payment method was found before trying to access its `paymentMethodID` property. This prevents errors from being thrown when trying to access a property of `undefined`
- Removed the unused transfer constant